### PR TITLE
Optionally display Twitter Name next to the @screenName in stream

### DIFF
--- a/lib/t/cli.rb
+++ b/lib/t/cli.rb
@@ -151,7 +151,7 @@ module T
         print_table_with_headings(array, DIRECT_MESSAGE_HEADINGS, format)
       else
         direct_messages.each do |direct_message|
-          print_message(direct_message.sender.screen_name, direct_message.text)
+          print_message(direct_message.sender, direct_message.text)
         end
       end
     end
@@ -186,7 +186,7 @@ module T
         print_table_with_headings(array, DIRECT_MESSAGE_HEADINGS, format)
       else
         direct_messages.each do |direct_message|
-          print_message(direct_message.recipient.screen_name, direct_message.text)
+          print_message(direct_message.recipient, direct_message.text)
         end
       end
     end

--- a/lib/t/printable.rb
+++ b/lib/t/printable.rb
@@ -113,9 +113,15 @@ module T
     def print_message(from_user, message)
       case options['color']
       when 'auto'
-        say("   @#{from_user}", [:bold, :yellow])
+        say("#{from_user.name}",[:bold, :cyan],false)
+        say(" - (",[],false)
+        say("@#{from_user.screen_name}", [:bold, :yellow],false)
+        say(")")      
       else
-        say("   @#{from_user}")
+        say("#{from_user.name}",[],false)
+        say(" - (",[],false)
+        say("@#{from_user.screen_name}", [],false)
+        say(")")
       end
       require 'htmlentities'
       print_wrapped(HTMLEntities.new.decode(message), :indent => 3)
@@ -138,7 +144,7 @@ module T
         print_table_with_headings(array, TWEET_HEADINGS, format)
       else
         tweets.each do |tweet|
-          print_message(tweet.user.screen_name, decode_uris(tweet.full_text, options['decode_uris'] ? tweet.uris : nil))
+          print_message(tweet.user, decode_uris(tweet.full_text, options['decode_uris'] ? tweet.uris : nil))
         end
       end
     end

--- a/lib/t/printable.rb
+++ b/lib/t/printable.rb
@@ -111,17 +111,26 @@ module T
     end
 
     def print_message(from_user, message)
+      # puts YAML::dump(from_user)
       case options['color']
       when 'auto'
-        say("#{from_user.name}",[:bold, :cyan],false)
-        say(" - (",[],false)
-        say("@#{from_user.screen_name}", [:bold, :yellow],false)
-        say(")")      
+        if (options['showname']) 
+          say("#{from_user.name}",[:bold, :cyan],false)
+          say(" - (",[],false)
+        end
+        say("@#{from_user.screen_name}", [:bold, :yellow],(options['showname'])?false:true)
+        if (options['showname'])
+          say(")")   
+        end   
       else
-        say("#{from_user.name}",[],false)
-        say(" - (",[],false)
-        say("@#{from_user.screen_name}", [],false)
-        say(")")
+        if (options['showname']) 
+          say("#{from_user.name}",[],false)
+          say(" - (",[],false)
+        end
+        say("@#{from_user.screen_name}", [],(options['showname'])?false:true)
+        if (options['showname'])
+          say(")")   
+        end   
       end
       require 'htmlentities'
       print_wrapped(HTMLEntities.new.decode(message), :indent => 3)

--- a/lib/t/search.rb
+++ b/lib/t/search.rb
@@ -51,7 +51,7 @@ module T
       else
         say unless tweets.empty?
         tweets.each do |tweet|
-          print_message(tweet.user.screen_name, decode_full_text(tweet, options['decode_uris']))
+          print_message(tweet.user, decode_full_text(tweet, options['decode_uris']))
         end
       end
     end

--- a/lib/t/stream.rb
+++ b/lib/t/stream.rb
@@ -54,7 +54,7 @@ module T
           end
           print_table([array], :truncate => STDOUT.tty?)
         else
-          print_message(tweet.user.screen_name, tweet.text)
+          print_message(tweet.user, tweet.text)
         end
       end
     end
@@ -90,7 +90,7 @@ module T
           end
           print_table([array], :truncate => STDOUT.tty?)
         else
-          print_message(tweet.user.screen_name, tweet.text)
+          print_message(tweet.user, tweet.text)
         end
       end
     end
@@ -137,7 +137,7 @@ module T
           end
           print_table([array], :truncate => STDOUT.tty?)
         else
-          print_message(tweet.user.screen_name, tweet.text)
+          print_message(tweet.user, tweet.text)
         end
       end
     end
@@ -169,7 +169,7 @@ module T
           end
           print_table([array], :truncate => STDOUT.tty?)
         else
-          print_message(tweet.user.screen_name, tweet.text)
+          print_message(tweet.user, tweet.text)
         end
       end
     end
@@ -206,7 +206,7 @@ module T
           end
           print_table([array], :truncate => STDOUT.tty?)
         else
-          print_message(tweet.user.screen_name, tweet.text)
+          print_message(tweet.user, tweet.text)
         end
       end
     end

--- a/lib/t/stream.rb
+++ b/lib/t/stream.rb
@@ -30,6 +30,7 @@ module T
     method_option 'long', :aliases => '-l', :type => :boolean, :desc => 'Output in long format.'
     method_option 'no-replies', :type => :boolean, :desc => 'Exclude replies.'
     method_option 'no-retweets', :type => :boolean, :desc => 'Exclude retweets.'
+    method_option 'showname', :aliases => '-n', :type => :boolean, :desc => 'Show twitter name in addition to @screenName.'
     def all
       streaming_client.before_request do
         if options['csv']
@@ -67,6 +68,7 @@ module T
     method_option 'no-replies', :type => :boolean, :desc => 'Exclude replies.'
     method_option 'no-retweets', :type => :boolean, :desc => 'Exclude retweets.'
     method_option 'reverse', :aliases => '-r', :type => :boolean, :desc => 'Reverse the order of the sort.'
+    method_option 'showname', :aliases => '-n', :type => :boolean, :desc => 'Show twitter name in addition to @screenName.'
     def list(user_list)
       owner, list_name = extract_owner(user_list, options)
       require 't/list'
@@ -115,6 +117,7 @@ module T
     method_option 'long', :aliases => '-l', :type => :boolean, :desc => 'Output in long format.'
     method_option 'no-replies', :type => :boolean, :desc => 'Exclude replies.'
     method_option 'no-retweets', :type => :boolean, :desc => 'Exclude retweets.'
+    method_option 'showname', :aliases => '-n', :type => :boolean, :desc => 'Show twitter name in addition to @screenName.'
     def search(keyword, *keywords)
       keywords.unshift(keyword)
       require 't/search'
@@ -148,6 +151,7 @@ module T
     method_option 'long', :aliases => '-l', :type => :boolean, :desc => 'Output in long format.'
     method_option 'no-replies', :type => :boolean, :desc => 'Exclude replies.'
     method_option 'no-retweets', :type => :boolean, :desc => 'Exclude retweets.'
+    method_option 'showname', :aliases => '-n', :type => :boolean, :desc => 'Show twitter name in addition to @screenName.'
     def timeline
       require 't/cli'
       streaming_client.before_request do
@@ -180,6 +184,7 @@ module T
     method_option 'long', :aliases => '-l', :type => :boolean, :desc => 'Output in long format.'
     method_option 'no-replies', :type => :boolean, :desc => 'Exclude replies.'
     method_option 'no-retweets', :type => :boolean, :desc => 'Exclude retweets.'
+    method_option 'showname', :aliases => '-n', :type => :boolean, :desc => 'Show twitter name in addition to @screenName.'
     def users(user_id, *user_ids)
       user_ids.unshift(user_id)
       user_ids.collect!(&:to_i)


### PR DESCRIPTION
Optionally, with -n, display the Twitter Name for a user next to their @screenName when viewing a stream. 

Example:
$ t stream timeline -n

Mike Bond - (@mbond) 
   Displaying Name along with @screenName

$ t stream timeline

@mbond
   Displaying Name along with @screenName
